### PR TITLE
Add few commands via a call to singular interpreter routines

### DIFF
--- a/deps/src/singular.cpp
+++ b/deps/src/singular.cpp
@@ -112,6 +112,15 @@ JLCXX_MODULE define_julia_module(jlcxx::Module & Singular)
                                            lv.rtyp = ANY_TYPE;
                                        });
 
+    Singular.method("set_leftv_arg_i", [](std::string x, int i, bool copy) {
+                                           // TODO (or not): avoid copying this poor string 2 or 3 times
+                                           assert(0 <= i && i <= 2);
+                                           auto &lv = i == 0 ? lvres : i == 1 ? lv1 : lv2;
+                                           lv.Init();
+                                           lv.data = (void*)(omStrDup(x.c_str()));
+                                           lv.rtyp = STRING_CMD;
+                                       });
+
     Singular.method("get_leftv_res", [] { return (void*)lvres.data; });
     Singular.method("iiExprArith1", [](int op) { return iiExprArith1(&lvres, &lv1, op); });
 

--- a/deps/src/singular.cpp
+++ b/deps/src/singular.cpp
@@ -123,6 +123,10 @@ JLCXX_MODULE define_julia_module(jlcxx::Module & Singular)
 
     Singular.method("get_leftv_res", [] { return (void*)lvres.data; });
     Singular.method("iiExprArith1", [](int op) { return iiExprArith1(&lvres, &lv1, op); });
+    Singular.method("iiExprArith2", [](int op) {
+                                        // TODO: check what is the default proccall argument
+                                        return iiExprArith2(&lvres, &lv1, op, &lv2);
+                                    });
 
     Singular.method("rChangeCurrRing", [](ring r) {
                                            ring old = currRing;

--- a/deps/src/singular.cpp
+++ b/deps/src/singular.cpp
@@ -86,12 +86,20 @@ JLCXX_MODULE define_julia_module(jlcxx::Module & Singular)
     singular_define_matrices(Singular);
     singular_define_coeff_rings(Singular);
 
-    Singular.method("set_leftv_arg_i", [](poly p, int i, bool copy) {
+    Singular.method("set_leftv_arg_i", [](poly x, int i, bool copy) {
                                            assert(0 <= i && i <= 2);
                                            auto &lv = i == 0 ? lvres : i == 1 ? lv1 : lv2;
                                            lv.Init();
-                                           lv.data = copy ? pCopy(p) : p;
+                                           lv.data = copy ? pCopy(x) : x;
                                            lv.rtyp = POLY_CMD;
+                                       });
+
+    Singular.method("set_leftv_arg_i", [](ideal x, int i, bool copy) {
+                                           assert(0 <= i && i <= 2);
+                                           auto &lv = i == 0 ? lvres : i == 1 ? lv1 : lv2;
+                                           lv.Init();
+                                           lv.data = copy ? idCopy(x) : x;
+                                           lv.rtyp = IDEAL_CMD;
                                        });
 
     Singular.method("get_leftv_res", [] { return (void*)lvres.data; });
@@ -102,6 +110,9 @@ JLCXX_MODULE define_julia_module(jlcxx::Module & Singular)
                                            rChangeCurrRing(r);
                                            return old;
                                        });
+
+    Singular.method("internal_void_to_ideal_helper",
+                      [](void * x) { return reinterpret_cast<ideal>(x); });
 
     // Calls the Singular interpreter with `input`.
     // `input` needs to be valid Singular input.

--- a/deps/src/singular.cpp
+++ b/deps/src/singular.cpp
@@ -102,6 +102,16 @@ JLCXX_MODULE define_julia_module(jlcxx::Module & Singular)
                                            lv.rtyp = IDEAL_CMD;
                                        });
 
+    // experimental
+    Singular.method("set_leftv_arg_i", [](void *x, int i, bool copy) {
+                                           assert(0 <= i && i <= 2);
+                                           assert(!copy);
+                                           auto &lv = i == 0 ? lvres : i == 1 ? lv1 : lv2;
+                                           lv.Init();
+                                           lv.data = x;
+                                           lv.rtyp = ANY_TYPE;
+                                       });
+
     Singular.method("get_leftv_res", [] { return (void*)lvres.data; });
     Singular.method("iiExprArith1", [](int op) { return iiExprArith1(&lvres, &lv1, op); });
 
@@ -113,6 +123,9 @@ JLCXX_MODULE define_julia_module(jlcxx::Module & Singular)
 
     Singular.method("internal_void_to_ideal_helper",
                       [](void * x) { return reinterpret_cast<ideal>(x); });
+
+    Singular.method("internal_to_void_helper",
+                      [](ring x) { return reinterpret_cast<void*>(x); });
 
     // Calls the Singular interpreter with `input`.
     // `input` needs to be valid Singular input.

--- a/src/runtime_cmds.jl
+++ b/src/runtime_cmds.jl
@@ -288,6 +288,35 @@ function rtkbase(a::SIdealData, b::Int)
 end
 
 
+##################### the lazy way: use sleftv's ##########
+
+op_code(cmd::CMDS) = Int(cmd) - 643 # 643: divergence from Singular
+
+function set_arg(x::SPoly, i, withcopy)
+    libSingular.rChangeCurrRing(x.parent.ring_ptr)
+    libSingular.set_leftv_arg_i(x.poly_ptr, i, withcopy)
+end
+
+set_arg1(x, withcopy=false) = set_arg(x, 1, withcopy)
+set_arg2(x, withcopy=false) = set_arg(x, 2, withcopy)
+
+get_res() = libSingular.get_leftv_res()
+get_res(::Type{SPoly}, r::SRing) =
+    SPoly(libSingular.internal_void_to_poly_helper(get_res()), r)
+
+cmd1(cmd::CMDS) = libSingular.iiExprArith1(op_code(cmd))
+
+### rtlead ###
+
+rtlead(a::STuple) = STuple(Any[rtlead(i) for i in a.list])
+
+function rtlead(x::SPoly)
+    set_arg1(x, true)
+    cmd1(LEAD_CMD)
+    get_res(SPoly, x.parent)
+end
+
+
 ##################### system stuff ########################
 
 function rt_get_rtimer()

--- a/src/runtime_cmds.jl
+++ b/src/runtime_cmds.jl
@@ -292,9 +292,9 @@ end
 
 op_code(cmd::CMDS) = Int(cmd) - 643 # 643: divergence from Singular
 
-function set_arg(x::SPoly, i, withcopy)
-    libSingular.rChangeCurrRing(x.parent.ring_ptr)
-    libSingular.set_leftv_arg_i(x.poly_ptr, i, withcopy)
+function set_arg(x::Union{SPoly,_Ideal}, i, withcopy)
+    libSingular.rChangeCurrRing(sing_ring(x).ring_ptr)
+    libSingular.set_leftv_arg_i(sing_ptr(x), i, withcopy)
 end
 
 set_arg1(x, withcopy=false) = set_arg(x, 1, withcopy)
@@ -304,16 +304,19 @@ get_res() = libSingular.get_leftv_res()
 get_res(::Type{SPoly}, r::SRing) =
     SPoly(libSingular.internal_void_to_poly_helper(get_res()), r)
 
+get_res(::Type{<:_Ideal}, r::SRing) =
+    SIdeal(SIdealData(libSingular.internal_void_to_ideal_helper(get_res()), r))
+
 cmd1(cmd::CMDS) = libSingular.iiExprArith1(op_code(cmd))
 
-### rtlead ###
+### lead ###
 
 rtlead(a::STuple) = STuple(Any[rtlead(i) for i in a.list])
 
-function rtlead(x::SPoly)
+function rtlead(x::Union{SPoly, _Ideal})
     set_arg1(x, true)
     cmd1(LEAD_CMD)
-    get_res(SPoly, x.parent)
+    get_res(typeof(x), sing_ring(x))
 end
 
 

--- a/src/runtime_cmds.jl
+++ b/src/runtime_cmds.jl
@@ -303,6 +303,12 @@ function set_arg(x::SRing, i, withcopy=false)
     libSingular.set_leftv_arg_i(v, i, withcopy)
 end
 
+function set_arg(x::SString, i, withcopy=false)
+    # TODO: handle gracefully when basering is not valid
+    # (not that Singular would handle that gracefully...)
+    libSingular.rChangeCurrRing(rt_basering().ring_ptr)
+    libSingular.set_leftv_arg_i(x.string, i , withcopy)
+end
 
 set_arg1(x, withcopy=false) = set_arg(x, 1, withcopy)
 set_arg2(x, withcopy=false) = set_arg(x, 2, withcopy)

--- a/src/runtime_cmds.jl
+++ b/src/runtime_cmds.jl
@@ -297,6 +297,13 @@ function set_arg(x::Union{SPoly,_Ideal}, i, withcopy)
     libSingular.set_leftv_arg_i(sing_ptr(x), i, withcopy)
 end
 
+function set_arg(x::SRing, i, withcopy=false)
+    libSingular.rChangeCurrRing(x.ring_ptr)
+    v = libSingular.internal_to_void_helper(x.ring_ptr)
+    libSingular.set_leftv_arg_i(v, i, withcopy)
+end
+
+
 set_arg1(x, withcopy=false) = set_arg(x, 1, withcopy)
 set_arg2(x, withcopy=false) = set_arg(x, 2, withcopy)
 
@@ -327,7 +334,7 @@ end
 rtrvar(a::STuple) = STuple(Any[rtrvar(i) for i in a.list])
 
 function rtrvar(x)
-    set_arg1(x, true) # needs to be copied!
+    set_arg1(x, !(x isa SRing)) # needs to be copied! (except for rings)
     cmd1(IS_RINGVAR)
     get_res(Int)
 end

--- a/src/runtime_cmds.jl
+++ b/src/runtime_cmds.jl
@@ -301,6 +301,9 @@ set_arg1(x, withcopy=false) = set_arg(x, 1, withcopy)
 set_arg2(x, withcopy=false) = set_arg(x, 2, withcopy)
 
 get_res() = libSingular.get_leftv_res()
+
+get_res(::Type{Int}) = Int(get_res())
+
 get_res(::Type{SPoly}, r::SRing) =
     SPoly(libSingular.internal_void_to_poly_helper(get_res()), r)
 
@@ -319,6 +322,15 @@ function rtlead(x::Union{SPoly, _Ideal})
     get_res(typeof(x), sing_ring(x))
 end
 
+### rvar ###
+
+rtrvar(a::STuple) = STuple(Any[rtrvar(i) for i in a.list])
+
+function rtrvar(x)
+    set_arg1(x, true) # needs to be copied!
+    cmd1(IS_RINGVAR)
+    get_res(Int)
+end
 
 ##################### system stuff ########################
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -207,6 +207,9 @@ mutable struct SPoly
     end
 end
 
+sing_ring(p::SPoly) = p.parent
+sing_ptr(p::SPoly) = p.poly_ptr
+
 function rt_poly_finalizer(a::SPoly)
     libSingular.p_Delete(a.poly_ptr, a.parent.ring_ptr)
     rt_ring_finalizer(a.parent)
@@ -227,6 +230,9 @@ mutable struct SIdealData
     end
 end
 
+sing_ptr(i::SIdealData) = i.ideal_ptr
+sing_ring(i::SIdealData) = i.parent
+
 function rt_ideal_finalizer(a::SIdealData)
     libSingular.id_Delete(a.ideal_ptr, a.parent.ring_ptr)
     rt_ring_finalizer(a.parent)
@@ -236,6 +242,8 @@ struct SIdeal
     ideal::SIdealData
 end
 
+sing_ptr(i::SIdeal) = sing_ptr(i.ideal)
+sing_ring(i::SIdeal) = sing_ring(i.ideal)
 
 #### singular type "matrix"
 mutable struct SMatrix

--- a/test/commands.sing
+++ b/test/commands.sing
@@ -1,0 +1,14 @@
+ring r;
+
+poly p = x^2+y;
+ideal id = (x, y^2+y);
+
+// lead
+ASSUME(0, lead(p) == x^2);
+ASSUME(0, p == x^2+y); // p not mutated
+ASSUME(0, lead(x^2+y^3) == y^3);
+ASSUME(0, lead((x^2+1, y+y^3)) == (x^2, y^3));
+
+ideal idlead = lead(id);
+ASSUME(0, idlead[1] == x);
+ASSUME(0, idlead[2] == y^2);

--- a/test/commands.sing
+++ b/test/commands.sing
@@ -20,3 +20,4 @@ ASSUME(0, rvar(y) == 2);
 ASSUME(0, rvar(z) == 3);
 ASSUME(0, rvar((x^2, y, x)) == (0, 2, 1));
 ASSUME(0, rvar(id) == 0);
+ASSUME(0, rvar(r) == 0);

--- a/test/commands.sing
+++ b/test/commands.sing
@@ -12,3 +12,11 @@ ASSUME(0, lead((x^2+1, y+y^3)) == (x^2, y^3));
 ideal idlead = lead(id);
 ASSUME(0, idlead[1] == x);
 ASSUME(0, idlead[2] == y^2);
+
+// rvar
+ASSUME(0, rvar(p) == 0);
+ASSUME(0, rvar(x) == 1);
+ASSUME(0, rvar(y) == 2);
+ASSUME(0, rvar(z) == 3);
+ASSUME(0, rvar((x^2, y, x)) == (0, 2, 1));
+ASSUME(0, rvar(id) == 0);

--- a/test/commands.sing
+++ b/test/commands.sing
@@ -21,3 +21,6 @@ ASSUME(0, rvar(z) == 3);
 ASSUME(0, rvar((x^2, y, x)) == (0, 2, 1));
 ASSUME(0, rvar(id) == 0);
 ASSUME(0, rvar(r) == 0);
+ASSUME(0, rvar("x") == 1);
+ASSUME(0, rvar("xy") == 0);
+ASSUME(0, rvar((x, "y")) == (1, 2));

--- a/test/poly.sing
+++ b/test/poly.sing
@@ -32,9 +32,3 @@ ASSUME(0, -(x+y) == -x-y);
 
 kill r; ring r;
 ASSUME(0, leadexp(x*(y+z)^2) == intvec(1, 2, 0));
-
-poly p = x^2+y;
-ASSUME(0, lead(p) == x^2);
-ASSUME(0, p == x^2+y); // p not mutated
-ASSUME(0, lead(x^2+y^3) == y^3);
-ASSUME(0, lead((x^2+1, y+y^3)) == (x^2, y^3))

--- a/test/poly.sing
+++ b/test/poly.sing
@@ -32,3 +32,9 @@ ASSUME(0, -(x+y) == -x-y);
 
 kill r; ring r;
 ASSUME(0, leadexp(x*(y+z)^2) == intvec(1, 2, 0));
+
+poly p = x^2+y;
+ASSUME(0, lead(p) == x^2);
+ASSUME(0, p == x^2+y); // p not mutated
+ASSUME(0, lead(x^2+y^3) == y^3);
+ASSUME(0, lead((x^2+1, y+y^3)) == (x^2, y^3))

--- a/test/poly.sing
+++ b/test/poly.sing
@@ -32,3 +32,10 @@ ASSUME(0, -(x+y) == -x-y);
 
 kill r; ring r;
 ASSUME(0, leadexp(x*(y+z)^2) == intvec(1, 2, 0));
+
+ASSUME(0, !(x < y));
+ASSUME(0, x > y);
+ASSUME(0, !(x <= y));
+ASSUME(0, x <= x);
+ASSUME(0, x >= y);
+ASSUME(0, !(y >= x));

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using SingularInterpreter
 using SingularInterpreter: rtcolon, rtequalequal, rtnot, rtand, rtor, SIntVec, SString
 
 for a in ["assign", "int", "intvec", "intmat", "bigintmat", "list",
-          "tuple", "proc", "poly", "ideal", "ring"]
+          "tuple", "proc", "poly", "ideal", "ring", "commands"]
     SingularInterpreter.reset_runtime()
     jlfile = joinpath(dirname(@__FILE__), a * ".jl")
     if isfile(jlfile)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ using SingularInterpreter
 using SingularInterpreter: rtcolon, rtequalequal, rtnot, rtand, rtor, SIntVec, SString
 
 for a in ["assign", "int", "intvec", "intmat", "bigintmat", "list",
-          "tuple", "proc", "poly", "ideal", "ring", "commands"]
+          "tuple", "proc", "poly", "ideal", "ring", "commands", "string"]
     SingularInterpreter.reset_runtime()
     jlfile = joinpath(dirname(@__FILE__), a * ".jl")
     if isfile(jlfile)

--- a/test/string.sing
+++ b/test/string.sing
@@ -1,0 +1,6 @@
+ASSUME(0, "a" < "b");
+ASSUME(0, "a" <= "b");
+ASSUME(0, "a" <= "a");
+ASSUME(0, !("a" > "b"));
+ASSUME(0, !("a" >= "b"));
+ASSUME(0, "a" >= "a");


### PR DESCRIPTION
This uses `iiExprArith1` and `iiExprArith2` Singular functions, which handle commands generically in the (original) Singular interpreter.
It's now easy to add more commands (which are of course then not optimally implemented).